### PR TITLE
Ensure that SV length is positive

### DIFF
--- a/variantFiltering/somaticVariants/somaticFilter.py
+++ b/variantFiltering/somaticVariants/somaticFilter.py
@@ -48,7 +48,7 @@ validRecordID = set()
 if args.vcfFile:
     vcf_reader = vcf.Reader(open(args.vcfFile), 'r', compressed=True) if args.vcfFile.endswith('.gz') else vcf.Reader(open(args.vcfFile), 'r', compressed=False)
     for record in vcf_reader:
-        svlen = record.INFO['END'] - record.POS
+        svlen = abs(record.INFO['END'] - record.POS)
         if (svlen >= minSize) and (svlen <= maxSize) and ((not args.siteFilter) or (len(record.FILTER) == 0)):
             precise = False
             if 'PRECISE' in record.INFO.keys():


### PR DESCRIPTION
I've run into translocations where the END on one chromosome is smaller than the POS on the other chromosome, causing svlen to be negative. As a result, even if I set `--minsize 0`, these events get excluded. I've included a simple one-line fix. 